### PR TITLE
remove the unused break, since php7 will report it as fatal

### DIFF
--- a/PHPExcel/Calculation/Functions.php
+++ b/PHPExcel/Calculation/Functions.php
@@ -571,7 +571,6 @@ class PHPExcel_Calculation_Functions {
 				return 4;
 		} elseif(is_array($value)) {
 				return 64;
-				break;
 		} elseif(is_string($value)) {
 			//	Errors
 			if ((strlen($value) > 0) && ($value{0} == '#')) {


### PR DESCRIPTION
Fatal error: 'break' not in the 'loop' or 'switch' context in vendor/codeplex/phpexcel/PHPExcel/Calculation/Functions.php on line <i>574</i>